### PR TITLE
Fix ValueError from repeated import ehtplot.color

### DIFF
--- a/ehtplot/color/core.py
+++ b/ehtplot/color/core.py
@@ -38,9 +38,9 @@ def register(name=None, cmap=None, path=None):
         if cmap is None:
             cmap = ListedColormap(load_ctab(name, path=path))
 
-        # Register the colormap
-        register_cmap(name=name, cmap=cmap)
+        # Register the colormap, overwriting if it already exists
+        register_cmap(name=name, cmap=cmap, override_builtin=True)
 
         # Register the reversed colormap
         register_cmap(name=name + ("_r" if unmodified(name) else "r"),
-                      cmap=cmap.reversed())
+                      cmap=cmap.reversed(), override_builtin=True)


### PR DESCRIPTION
If a script importing this module is run more than once, it produces

    ValueError: A colormap named "afmhot_10u" is already registered.

Now it overwrites the existing colormaps instead, and fixes #5.